### PR TITLE
Update NavigationBar component to rely only on inline styles

### DIFF
--- a/components/NavigationBar.jsx
+++ b/components/NavigationBar.jsx
@@ -16,7 +16,7 @@ const h1Styling = css({
   fontSize: '1.7rem',
   ...lineHeight,
   '& > a': {
-    color: COLORS.GREY_DARK,
+    color: COLORS.GREY_DARK + ' !important',
     paddingLeft: '.3em'
   }
 });
@@ -34,9 +34,7 @@ const headerStyling = css({
 
 const clearingDivStyling = css({
   borderBottom: '1px solid ' + COLORS.GREY_LIGHT,
-  clear: 'both',
-  display: 'block',
-  lineHeight: 0
+  clear: 'both'
 });
 
 export default class NavigationBar extends React.Component {

--- a/components/NavigationBar.jsx
+++ b/components/NavigationBar.jsx
@@ -27,6 +27,18 @@ const pushLeftStyling = css({
   ...lineHeight
 });
 
+const headerStyling = css({
+  background: COLORS.WHITE,
+  ...lineHeight
+});
+
+const clearingDivStyling = css({
+  borderBottom: '1px solid ' + COLORS.GREY_LIGHT,
+  clear: 'both',
+  display: 'block',
+  lineHeight: 0
+});
+
 export default class NavigationBar extends React.Component {
   render() {
     const {
@@ -40,7 +52,7 @@ export default class NavigationBar extends React.Component {
     } = this.props;
 
     return <div>
-      <header>
+      <header {...headerStyling}>
         <div>
           <div {...getAppWidthStyling(wideApp)}>
             <span className="cf-push-left" {...pushLeftStyling}>
@@ -71,7 +83,7 @@ export default class NavigationBar extends React.Component {
             </span>
           </div>
         </div>
-        {this.props.extraBanner}
+        <div {...clearingDivStyling}> </div>
       </header>
       {this.props.children}
     </div>;

--- a/components/NavigationBar.jsx
+++ b/components/NavigationBar.jsx
@@ -16,7 +16,7 @@ const h1Styling = css({
   fontSize: '1.7rem',
   ...lineHeight,
   '& > a': {
-    color: COLORS.GREY_DARK + ' !important',
+    color: `${COLORS.GREY_DARK} + !important`,
     paddingLeft: '.3em'
   }
 });
@@ -33,7 +33,7 @@ const headerStyling = css({
 });
 
 const clearingDivStyling = css({
-  borderBottom: '1px solid ' + COLORS.GREY_LIGHT,
+  borderBottom: `1px solid ${COLORS.GREY_LIGHT}`,
   clear: 'both'
 });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/appeals-frontend-toolkit",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Build tools and React components for the Appeals frontends",
   "main": "index.js",
   "repository": "git@github.com:department-of-veterans-affairs/appeals-frontend-toolkit.git",

--- a/util/StyleConstants.js
+++ b/util/StyleConstants.js
@@ -3,6 +3,7 @@ import { css } from 'glamor';
 export const COLORS = {
   PRIMARY_ALT: '#02bfe7',
 
+  GREY_LIGHT: '#d6d7d9',
   GREY_MEDIUM: '#757575',
   GREY_DARK: '#323a45',
 


### PR DESCRIPTION
In attempting to use NavigationBar for the efolder express react rewrite, we discovered that the `<header>` html element depended on some styles that existed in the main caseflow repo's stylesheets. This PR allows the NavigationBar component to render properly even in the absence of that stylesheet because we moved those styles into the component itself.